### PR TITLE
Update action to support Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.10
+FROM node:20
 
 RUN apk add --no-cache coreutils wget git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git config --global --add safe.directory /github/workspace
-
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
+RUN git config --global --add safe.directory /github/workspace
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM alpine:3.10
 FROM node:20
 
-RUN apk add --no-cache coreutils wget git
+RUN apt-get update && apt-get install -y \
+    coreutils \
+    wget \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,8 @@ wget "$url" -O "$file_in_repo"
 git config user.name "$git_name"
 git config user.email "$git_email"
 
+git config --global --add safe.directory /github/workspace
+
 git add "$file_in_repo"
 git commit -m "Update $(basename "$file_in_repo") from $url"
 git push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,8 @@ git_email="$4"
 mkdir -p "$(dirname "$file_in_repo")"
 wget "$url" -O "$file_in_repo"
 
-git config user.name "$git_name"
-git config user.email "$git_email"
-
+git config --global user.name "$git_name"
+git config --global user.email "$git_email"
 git config --global --add safe.directory /github/workspace
 
 git add "$file_in_repo"


### PR DESCRIPTION
RE: [GitHub Announcement, March 2024](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) -

> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 3rd of June.

Currently, this action outputs a warning about its usage of Node 16, but starting from 3rd June 2024, this will become a failure at runtime.

I've forked my own version to ensure it continues running locally; this is what worked for me (it's almost all ChatGPT-generated as I'm out of my depth):

* Changed Dockerfile to specify a Node 20 base image
* The `RUN` command failed until ~I~ ChatGPT converted it to a Node 20 friendly version
* Presumably the Node 20 base image uses a different file structure, because this led to a runtime error: `fatal: detected dubious ownership in repository at '/github/workspace'` - added the necessary `safe.directory` into the script (and had to promote user name/email to global for it to pick them up, too)

Long story short, the old behaviour is restored with these changes, but you might prefer to make your own, better changes (or at least squash-merge to deal with all my random debugging steps)